### PR TITLE
FIX: input file refference key

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -38456,7 +38456,7 @@ async function run() {
   try {
     const token = core.getInput("token");
     const prNumber = core.getInput("pr_number");
-    const resultsPath = core.getInput("pytest_results");
+    const resultsPath = core.getInput("results");
 
     const xmlData = fs.readFileSync(resultsPath, "utf-8");
     const parser = new xml2js.Parser();

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ async function run() {
   try {
     const token = core.getInput("token");
     const prNumber = core.getInput("pr_number");
-    const resultsPath = core.getInput("pytest_results");
+    const resultsPath = core.getInput("results");
 
     const xmlData = fs.readFileSync(resultsPath, "utf-8");
     const parser = new xml2js.Parser();


### PR DESCRIPTION
This pull request includes a change to the `index.js` file to update the input parameter name for the path to test results.

* [`index.js`](diffhunk://#diff-e727e4bdf3657fd1d798edcd6b099d6e092f8573cba266154583a746bba0f346L10-R10): Changed the input parameter name from `pytest_results` to `results` in the `run` function.